### PR TITLE
add template dependencies to loader dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ module.exports = function(source) {
   }
 
   var template = ejs.compile(source, opts);
+  template.dependencies.forEach(this.dependency.bind(this));
 
   // Beautify javascript code
   if (this.loaders.length > 1) {


### PR DESCRIPTION
In its current state, only the loader's input EJS file is defined as a dependency.
It means that everytime we update the file, webpack will trigger a new processing.

Problem is when we add included file to the template with one of those directives :

```
<%- include('../ejs/footer.ejs') %>
<%- include ../ejs/footer.ejs %>
```

We can check that EJS transitive dependencies are not exposed by looking into `template.dependencies` content.

As this loader is a LoaderContext instance, we have access to `this.dependency` which allow adding dependencies to this entry file processing :

```
function addDependency(file) {
	fileDependencies.push(file);
}
```

To declare EJS dependencies, we need to bind it from EJS to the loader :

```
template.dependencies.forEach(this.dependency.bind(this));
```
