### PR TITLE
add flag to disable template wrapping into module.exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Following options can be specified in query:
 
 `htmlmin` — see [htmlminify section](#htmlminify)
 
+`rawTemplate` - see [rawTemplate section](#rawTemplate)
+
 ## htmlminify
 
 ```javascript
@@ -168,6 +170,57 @@ module: {
 ```
 
 See [all options reference](https://github.com/kangax/html-minifier#options-quick-reference)
+
+## rawTemplate
+
+Simpliest use for this loader is :
+
+```javascript
+module: {
+    rules: [
+        {
+            test: /\.ejs$/,
+            use: [
+                {
+                  loader: "ejs-webpack-loader"
+                }
+            ]
+        }
+    ]
+}
+```
+
+Still, in some case, you want to be able to modify the output HTML stream.
+To do so, you'll need the raw HTML stream, not an escaped string stored as a "module.exports".
+
+Here is an example that process the EJS output through prettier formatter :
+
+```javascript
+module: {
+    rules: [
+        {
+            test: /\.ejs$/,
+            use: [
+                {
+                  loader: "html-loader"
+                },
+                {
+                  loader: "prettier-loader",
+                  options: {
+                    filepath: "foobar.html"
+                  }
+                },
+                {
+                  loader: "ejs-webpack-loader",
+                  options: {
+                    rawTemplate: true // default value is false
+                  }
+                }
+            ]
+        }
+    ]
+}
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -47,8 +47,5 @@ module.exports = function(source) {
       template = ast.print_to_string({beautify: true});
     }
   }
-  if (opts.disableModuleExports) {
-    return template;
-  }
   return 'module.exports = ' + template;
 };

--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ module.exports = function(source) {
   var template = ejs.compile(source, opts);
   template.dependencies.forEach(this.dependency.bind(this));
 
+  if (opts.rawTemplate) {
+    return template((opts['data'] || {}));
+  }
+
   // Beautify javascript code
   if (this.loaders.length > 1) {
     template = JSON.stringify(template((opts['data'] || {})));
@@ -42,6 +46,9 @@ module.exports = function(source) {
       ast.figure_out_scope();
       template = ast.print_to_string({beautify: true});
     }
+  }
+  if (opts.disableModuleExports) {
+    return template;
   }
   return 'module.exports = ' + template;
 };


### PR DESCRIPTION
By default, loader output template as `module.exports = "..escaped html string.."`.
This PR allow to export the raw html stream in order to be manipulated later on the loader chain.